### PR TITLE
Karaoke: clickable song title opens modal, separate English/Pinyin toggles

### DIFF
--- a/page/karaoke/index.html
+++ b/page/karaoke/index.html
@@ -27,10 +27,10 @@
   <body class="has-header">
     <div id="header">
       <a id="home-link" class="header-back" href="#">&#8592;</a>
-      <span id="song-title" class="header-title"></span>
+      <span id="song-title" class="header-title" onclick="karaokePage.openModal()"></span>
       <div class="header-actions">
-        <a onclick="karaokePage.openModal()" class="header-action">Song</a>
-        <a onclick="karaokePage.toggleMode()" id="pinyin-toggle" class="header-action">Pinyin Off</a>
+        <a onclick="karaokePage.toggleEnglish()" id="english-toggle" class="header-action">English Off</a>
+        <a onclick="karaokePage.togglePinyin()" id="pinyin-toggle" class="header-action">Pinyin Off</a>
       </div>
     </div>
     <div id="modal">

--- a/page/karaoke/karaoke.js
+++ b/page/karaoke/karaoke.js
@@ -49,15 +49,10 @@ function buildWordBlocks(phrase, pinyinStr) {
   return result;
 }
 
-const MODES = [
-  { label: 'Pinyin Off', lyricClass: '' },
-  { label: 'Pinyin On',  lyricClass: 'show-pinyin' },
-  { label: 'Show All',   lyricClass: 'show-both' },
-];
-
 class KaraokePage {
   constructor() {
-    this.mode = 0;
+    this.showPinyin = false;
+    this.showEnglish = false;
     this.songs = [];
   }
 
@@ -131,13 +126,20 @@ class KaraokePage {
   }
 
   applyMode() {
-    const { label, lyricClass } = MODES[this.mode];
-    $('#lyrics').removeClass('show-pinyin show-both').addClass(lyricClass);
-    $('#pinyin-toggle').text(label);
+    $('#lyrics')
+      .toggleClass('show-pinyin', this.showPinyin)
+      .toggleClass('show-english', this.showEnglish);
+    $('#pinyin-toggle').text(this.showPinyin ? 'Pinyin On' : 'Pinyin Off');
+    $('#english-toggle').text(this.showEnglish ? 'English On' : 'English Off');
   }
 
-  toggleMode() {
-    this.mode = (this.mode + 1) % MODES.length;
+  togglePinyin() {
+    this.showPinyin = !this.showPinyin;
+    this.applyMode();
+  }
+
+  toggleEnglish() {
+    this.showEnglish = !this.showEnglish;
     this.applyMode();
   }
 }

--- a/page/karaoke/style.css
+++ b/page/karaoke/style.css
@@ -1,6 +1,7 @@
 #song-title {
   font-size: 11px;
   color: #999;
+  cursor: pointer;
 }
 
 /* lyrics */
@@ -44,8 +45,7 @@
   transition: opacity 0.15s;
 }
 
-#lyrics.show-pinyin .lyric-pinyin,
-#lyrics.show-both .lyric-pinyin {
+#lyrics.show-pinyin .lyric-pinyin {
   opacity: 0.8;
 }
 
@@ -56,7 +56,7 @@
   transition: opacity 0.15s;
 }
 
-#lyrics.show-both .lyric-english {
+#lyrics.show-english .lyric-english {
   opacity: 0.7;
 }
 


### PR DESCRIPTION
- Remove Song button from header; clicking the song title now opens the song picker modal
- Replace the three-state Pinyin cycle (Off → Pinyin On → Show All) with two independent toggles — Pinyin Off/On and English Off/On

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajRtrrKYuoL12QgXZgkTw)_